### PR TITLE
Emoji Fix

### DIFF
--- a/Enigma/Enigma/EncrytionFramework.m
+++ b/Enigma/Enigma/EncrytionFramework.m
@@ -38,7 +38,34 @@
 	NSLog(@"Decryted to %@", newString);
 }
 
++(NSString*) removeEmojiFromString:(NSString *)string {
+	__block NSMutableString* temp = [NSMutableString string];
+	
+	[string enumerateSubstringsInRange: NSMakeRange(0, [string length]) options:NSStringEnumerationByComposedCharacterSequences usingBlock:
+	 ^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop){
+		 
+		 const unichar hs = [substring characterAtIndex: 0];
+		 
+		 // surrogate pair
+		 if (0xd800 <= hs && hs <= 0xdbff) {
+			 const unichar ls = [substring characterAtIndex: 1];
+			 const int uc = ((hs - 0xd800) * 0x400) + (ls - 0xdc00) + 0x10000;
+			 
+			 [temp appendString: (0x1d000 <= uc && uc <= 0x1f77f)? @"?": substring]; // U+1D000-1F77F
+			 
+			 // non surrogate
+		 } else {
+			 [temp appendString: (0x2100 <= hs && hs <= 0x26ff)? @"?": substring]; // U+2100-26FF
+		 }
+	 }];
+	
+	return temp;
+}
+
 +(NSString *) encrypt:(NSString *)message Using:(EncryptionType)encrytionType withKey:(NSString *)key1 andKey:(int)key2 {
+	
+	message = [self removeEmojiFromString:message];
+	
 	const char *CString = [message cStringUsingEncoding:NSASCIIStringEncoding];
 	char *newCString;
 	
@@ -61,6 +88,9 @@
 }
 
 +(NSString *) decrypt:(NSString *)message Using:(EncryptionType)encrytionType withKey:(NSString *)key1 andKey:(int)key2 {
+	
+	message = [self removeEmojiFromString:message];
+	
 	const char *CString = [message cStringUsingEncoding:NSASCIIStringEncoding];
 	char *newCString;
 	


### PR DESCRIPTION
Emoji now encrypts/decrypts as '?'. Due to ASCII conversions this was the easiest solution. I'm going to look into getting them to skip over the emoji so it shows in the decryption view but this make take some time.