### PR TITLE
Added the ability to see and manage profile names

### DIFF
--- a/Enigma/Enigma/AppDelegate.swift
+++ b/Enigma/Enigma/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Split view controller
 		let splitViewController = self.window!.rootViewController as SplitViewController
         
-        splitViewController.managedObjectContext = self.managedObjectContext
+		splitViewController.managedObjectContext = self.managedObjectContext
 		
 		return true
 	}
@@ -52,74 +52,73 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 	func applicationWillTerminate(application: UIApplication) {
 		// Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-        self.saveContext()
-    }
-    
-    // MARK: - Core Data stack
-    
-    lazy var applicationDocumentsDirectory: NSURL = {
-        // The directory the application uses to store the Core Data store file. This code uses a directory named "com.Danwakeem.Brace_Editor" in the application's documents Application Support directory.
-        //let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
-        //return urls[urls.count-1] as NSURL
-        
-        let urls = NSFileManager.defaultManager().containerURLForSecurityApplicationGroupIdentifier("group.com.enigma")
-        return urls!
-        
-        }()
-    
-    lazy var managedObjectModel: NSManagedObjectModel = {
-        // The managed object model for the application. This property is not optional. It is a fatal error for the application not to be able to find and load its model.
-        let modelURL = NSBundle.mainBundle().URLForResource("Enigma", withExtension: "momd")!
-        return NSManagedObjectModel(contentsOfURL: modelURL)!
-        }()
-    
-    lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator? = {
-        // The persistent store coordinator for the application. This implementation creates and return a coordinator, having added the store for the application to it. This property is optional since there are legitimate error conditions that could cause the creation of the store to fail.
-        // Create the coordinator and store
-        var coordinator: NSPersistentStoreCoordinator? = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
-        let url = self.applicationDocumentsDirectory.URLByAppendingPathComponent("Enigma.sqlite")
-        var error: NSError? = nil
-        var failureReason = "There was an error creating or loading the application's saved data."
-        if coordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: url, options: nil, error: &error) == nil {
-            coordinator = nil
-            // Report any error we got.
-            let dict = NSMutableDictionary()
-            dict[NSLocalizedDescriptionKey] = "Failed to initialize the application's saved data"
-            dict[NSLocalizedFailureReasonErrorKey] = failureReason
-            dict[NSUnderlyingErrorKey] = error
-            error = NSError(domain: "YOUR_ERROR_DOMAIN", code: 9999, userInfo: dict)
-            // Replace this with code to handle the error appropriately.
-            // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            NSLog("Unresolved error \(error), \(error!.userInfo)")
-            abort()
-        }
-        
-        return coordinator
-        }()
-    
-    lazy var managedObjectContext: NSManagedObjectContext? = {
-        // Returns the managed object context for the application (which is already bound to the persistent store coordinator for the application.) This property is optional since there are legitimate error conditions that could cause the creation of the context to fail.
-        let coordinator = self.persistentStoreCoordinator
-        if coordinator == nil {
-            return nil
-        }
-        var managedObjectContext = NSManagedObjectContext()
-        managedObjectContext.persistentStoreCoordinator = coordinator
-        return managedObjectContext
-        }()
-    
-    // MARK: - Core Data Saving support
-    
-    func saveContext () {
-        if let moc = self.managedObjectContext {
-            var error: NSError? = nil
-            if moc.hasChanges && !moc.save(&error) {
-                // Replace this implementation with code to handle the error appropriately.
-                // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                NSLog("Unresolved error \(error), \(error!.userInfo)")
-                abort()
-            }
-        }
-    }
+		self.saveContext()
+	}
+
+	// MARK: - Core Data stack
+
+	lazy var applicationDocumentsDirectory: NSURL = {
+		// The directory the application uses to store the Core Data store file. This code uses a directory named "com.Danwakeem.Brace_Editor" in the application's documents Application Support directory.
+		//let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
+		//return urls[urls.count-1] as NSURL
+
+		let urls = NSFileManager.defaultManager().containerURLForSecurityApplicationGroupIdentifier("group.com.enigma")
+		return urls!
+	}()
+
+	lazy var managedObjectModel: NSManagedObjectModel = {
+		// The managed object model for the application. This property is not optional. It is a fatal error for the application not to be able to find and load its model.
+		let modelURL = NSBundle.mainBundle().URLForResource("Enigma", withExtension: "momd")!
+		return NSManagedObjectModel(contentsOfURL: modelURL)!
+	}()
+
+	lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator? = {
+		// The persistent store coordinator for the application. This implementation creates and return a coordinator, having added the store for the application to it. This property is optional since there are legitimate error conditions that could cause the creation of the store to fail.
+		// Create the coordinator and store
+		var coordinator: NSPersistentStoreCoordinator? = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
+		let url = self.applicationDocumentsDirectory.URLByAppendingPathComponent("Enigma.sqlite")
+		var error: NSError? = nil
+		var failureReason = "There was an error creating or loading the application's saved data."
+		if coordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: url, options: nil, error: &error) == nil {
+			coordinator = nil
+			// Report any error we got.
+			let dict = NSMutableDictionary()
+			dict[NSLocalizedDescriptionKey] = "Failed to initialize the application's saved data"
+			dict[NSLocalizedFailureReasonErrorKey] = failureReason
+			dict[NSUnderlyingErrorKey] = error
+			error = NSError(domain: "YOUR_ERROR_DOMAIN", code: 9999, userInfo: dict)
+			// Replace this with code to handle the error appropriately.
+			// abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+			NSLog("Unresolved error \(error), \(error!.userInfo)")
+			abort()
+		}
+
+		return coordinator
+	}()
+
+	lazy var managedObjectContext: NSManagedObjectContext? = {
+		// Returns the managed object context for the application (which is already bound to the persistent store coordinator for the application.) This property is optional since there are legitimate error conditions that could cause the creation of the context to fail.
+		let coordinator = self.persistentStoreCoordinator
+		if coordinator == nil {
+			return nil
+		}
+		var managedObjectContext = NSManagedObjectContext()
+		managedObjectContext.persistentStoreCoordinator = coordinator
+		return managedObjectContext
+	}()
+
+	// MARK: - Core Data Saving support
+
+	func saveContext () {
+		if let moc = self.managedObjectContext {
+			var error: NSError? = nil
+			if moc.hasChanges && !moc.save(&error) {
+				// Replace this implementation with code to handle the error appropriately.
+				// abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+				NSLog("Unresolved error \(error), \(error!.userInfo)")
+				abort()
+			}
+		}
+	}
 }
 

--- a/Enigma/Enigma/Base.lproj/Main.storyboard
+++ b/Enigma/Enigma/Base.lproj/Main.storyboard
@@ -256,6 +256,9 @@
                                     <rect key="frame" x="8" y="8" width="584" height="30"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                     <textInputTraits key="textInputTraits"/>
+                                    <connections>
+                                        <outlet property="delegate" destination="p7B-gN-xwT" id="Hgw-TB-d8D"/>
+                                    </connections>
                                 </textField>
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/Enigma/Enigma/Enigma.xcdatamodeld/Enigma.xcdatamodel/contents
+++ b/Enigma/Enigma/Enigma.xcdatamodeld/Enigma.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14C109" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14D87h" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Encryptions" syncable="YES">
         <attribute name="encryptionType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="key1" optional="YES" attributeType="String" syncable="YES"/>
@@ -12,7 +12,7 @@
         <relationship name="encryption" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Encryptions" inverseName="profiles" inverseEntity="Encryptions" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Encryptions" positionX="187" positionY="5" width="128" height="103"/>
-        <element name="Profiles" positionX="-63" positionY="-18" width="128" height="88"/>
+        <element name="Encryptions" positionX="205" positionY="-31" width="128" height="103"/>
+        <element name="Profiles" positionX="-63" positionY="-16" width="128" height="88"/>
     </elements>
 </model>

--- a/Enigma/Enigma/ProfileDetailCell.swift
+++ b/Enigma/Enigma/ProfileDetailCell.swift
@@ -8,7 +8,17 @@
 
 import UIKit
 
-class ProfileDetailCell: UICollectionViewCell {
+protocol ProfileDetailCellDelegate {
+	func cypherChanged(cypher: String, key1: String, key2: String)
+}
+
+class ProfileDetailCell: UICollectionViewCell, UITextFieldDelegate {
 	@IBOutlet weak var cypherButton: UIButton!
 	@IBOutlet weak var keyField: UITextField!
+	
+	var delegate: ProfileDetailCellDelegate! = nil
+	
+	func textFieldDidEndEditing(textField: UITextField) {
+		delegate.cypherChanged("Caesar", key1: keyField.text, key2: "")
+	}
 }

--- a/Enigma/Enigma/ProfileDetailHeaderView.swift
+++ b/Enigma/Enigma/ProfileDetailHeaderView.swift
@@ -8,8 +8,16 @@
 
 import UIKit
 
-class ProfileDetailHeaderView: UICollectionReusableView {
+protocol ProfileDetailHeaderViewDelegate {
+	func profileNameChanged(name: String)
+}
+
+class ProfileDetailHeaderView: UICollectionReusableView, UITextFieldDelegate {
 	@IBOutlet weak var profileNameField: UITextField!
 	
+	var delegate: ProfileDetailHeaderViewDelegate! = nil
 	
+	func textFieldDidEndEditing(textField: UITextField) {
+		delegate.profileNameChanged(textField.text)
+	}
 }

--- a/Enigma/Enigma/ProfileDetailViewController.swift
+++ b/Enigma/Enigma/ProfileDetailViewController.swift
@@ -7,9 +7,10 @@
 //
 
 import UIKit
+import CoreData
 
-class ProfileDetailViewController: UICollectionViewController {
-	var name: String = ""
+class ProfileDetailViewController: UICollectionViewController, ProfileDetailHeaderViewDelegate, ProfileDetailCellDelegate {
+	var profile: NSManagedObject? = nil
 	var encryptionMethods = [ "Affine", "Ceasar" ]
 	
 	@IBAction func toggleEdit(sender: AnyObject) {
@@ -22,7 +23,7 @@ class ProfileDetailViewController: UICollectionViewController {
 		collectionView!.reloadData()
 		
 		UIView.setAnimationsEnabled(animated)
-		navigationItem.rightBarButtonItem?.title = editing ? "Done" : "Edit"
+		navigationItem.rightBarButtonItem?.title = editing ? "Save" : "Edit"
 		navigationItem.rightBarButtonItem?.style = editing ? .Done : .Plain;
 		UIView.setAnimationsEnabled(true)
 	}
@@ -47,6 +48,7 @@ class ProfileDetailViewController: UICollectionViewController {
 		cell.layer.borderColor = UIColor(white: 204.0/255.0, alpha: 1.0).CGColor
 		cell.layer.borderWidth = 0.5
 		
+		cell.delegate = self
 		cell.cypherButton.setTitle("Caesar", forState: .Normal)
 		cell.cypherButton.enabled = editing
 		cell.keyField.text = "123"
@@ -62,7 +64,8 @@ class ProfileDetailViewController: UICollectionViewController {
 			var headerView = collectionView.dequeueReusableSupplementaryViewOfKind(UICollectionElementKindSectionHeader, withReuseIdentifier: "Header", forIndexPath: indexPath) as ProfileDetailHeaderView
 			
 			// set up profile data
-			headerView.profileNameField.text = name
+			headerView.delegate = self
+			headerView.profileNameField.text = profile?.valueForKey("name") as String!
 			headerView.profileNameField.enabled = editing
 			
 			reusableView = headerView
@@ -73,5 +76,26 @@ class ProfileDetailViewController: UICollectionViewController {
 	
 	override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
 		return 1
+	}
+	
+	func profileNameChanged(name: String) {
+		let appDelegate = UIApplication.sharedApplication().delegate as AppDelegate
+		let managedContext = appDelegate.managedObjectContext!
+		
+		profile?.setValue(name, forKey: "name")
+		
+		var error: NSError?
+		if !managedContext.save(&error) {
+			println("Could not save \(error), \(error?.userInfo)")
+		}
+		
+		NSNotificationCenter.defaultCenter().postNotificationName("ProfileUpdated", object: profile)
+	}
+	
+	func cypherChanged(cypher: String, key1: String, key2: String) {
+		let appDelegate = UIApplication.sharedApplication().delegate as AppDelegate
+		let managedContext = appDelegate.managedObjectContext!
+		
+		
 	}
 }

--- a/Enigma/Enigma/SettingsViewController.swift
+++ b/Enigma/Enigma/SettingsViewController.swift
@@ -11,17 +11,11 @@ import UIKit
 class SettingsViewController: UITableViewController, PasscodeViewDelegate {
 	
 	override func viewDidLoad() {
-		
+		super.viewDidLoad()
 	}
 	
 	override func viewDidAppear(animated: Bool) {
 		super.viewDidAppear(animated)
-		
-		setNeedsStatusBarAppearanceUpdate()
-	}
-	
-	override func preferredStatusBarStyle() -> UIStatusBarStyle {
-		return .LightContent
 	}
 	
 	override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Enigma/Enigma/SplitViewController.swift
+++ b/Enigma/Enigma/SplitViewController.swift
@@ -24,9 +24,6 @@ class SplitViewController: UISplitViewController, UISplitViewControllerDelegate,
 	required init(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		delegate = self
-		
-		//let navigationController = viewControllers[viewControllers.count-1] as UINavigationController
-		//navigationController.topViewController.navigationItem.leftBarButtonItem = displayModeButtonItem()
 	}
 	
 	override func viewDidAppear(animated: Bool) {


### PR DESCRIPTION
I did a quick hookup of Core Data to the table view. Names can be changed in the detail view, and profiles can be quickly deleted by swiping left on them in the master list (this will probably be changed later to prevent accidental data loss).